### PR TITLE
fix: make X-Oauth-Token available

### DIFF
--- a/src/access.lua
+++ b/src/access.lua
@@ -207,6 +207,7 @@ function _M.run(conf)
 		      ngx.header["X-Oauth-".. key] = userInfo[key]
 		      ngx.req.set_header("X-Oauth-".. key, userInfo[key])
 		  end
+		      ngx.req.set_header("X-Oauth-Token", access_token)
 		      ngx.header["X-Oauth-Token"] = access_token	
 		  return
 		end
@@ -229,6 +230,7 @@ function _M.run(conf)
 			ngx.header["X-Oauth-".. key] = json[key]
 			ngx.req.set_header("X-Oauth-".. key, json[key])
 		    end
+		    ngx.req.set_header("X-Oauth-Token", access_token)
 		    ngx.header["X-Oauth-Token"] = access_token
 
 		    if type(ngx.header["Set-Cookie"]) == "table" then


### PR DESCRIPTION
Previously, only X-UserInfo fields were available for upstream services. This makes the entire X-Oauth-Token available.