### PR TITLE
feat: specify realm header

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ $ curl -X POST http://kong:8001/apis/{api}/plugins \
 | `config.app_login_redirect_url` 		  | | Needed for Single Page Applications to redirect after initial authentication successful, otherwise a proxy request following initial authentication would redirect data directly to a users browser! |
 | `config.cookie_domain` 		  | | Specify the domain in which this cookie is valid for, realistically will need to match the gateway |
 | `config.user_info_cache_enabled` 		  | | This enables storing the userInfo in Kong local cache which enables sending the entire requested user information to the backend service upon every request, otherwise user info only comes back occasionally and backend api service providers are required to validate the EOAuth Cookie Session with cached user information within their logic |
+| `config.realm`        | | (Optional) This value will be passed as `X-Oauth-realm` _if and only if_ it is included as part of the request URL. |
 
 In addition to the `user_keys` will be added a `X-OAUTH-TOKEN` header with the access token of the provider.
 

--- a/src/access.lua
+++ b/src/access.lua
@@ -224,8 +224,11 @@ function _M.run(conf)
 		      ngx.header["X-Oauth-".. key] = userInfo[key]
 		      ngx.req.set_header("X-Oauth-".. key, userInfo[key])
 		  end
-		      ngx.req.set_header("X-Oauth-Token", access_token)
-		      ngx.header["X-Oauth-Token"] = access_token
+      if (conf.realm ~= "" and (pl_stringx.count(ngx.var.request_uri, conf.realm) > 0)) then -- inject realm name into headers
+       ngx.header["X-Oauth-realm"] = conf.realm
+      end
+      ngx.req.set_header("X-Oauth-Token", access_token)
+      ngx.header["X-Oauth-Token"] = access_token
 		  return
 		end
   end
@@ -247,6 +250,9 @@ function _M.run(conf)
     			ngx.header["X-Oauth-".. key] = json[key]
     			ngx.req.set_header("X-Oauth-".. key, json[key])
 		    end
+        if (conf.realm ~= "" and (pl_stringx.count(ngx.var.request_uri, conf.realm) > 0)) then -- inject realm name into headers
+          ngx.header["X-Oauth-realm"] = conf.realm
+        end
 		    ngx.req.set_header("X-Oauth-Token", access_token)
 		    ngx.header["X-Oauth-Token"] = access_token
 

--- a/src/schema.lua
+++ b/src/schema.lua
@@ -32,6 +32,7 @@ return {
     cookie_domain = {type = "string", default = ".company.com"},
     user_info_periodic_check = {type = "number", required = true, default = 60},
     hosted_domain = {type = "string", default = ""},
+    realm = {type = "string", default = ""},
     email_key = {type = "string", default = ""},
     user_info_cache_enabled = {type = "boolean", default = false}
   }


### PR DESCRIPTION
We needed a way to optionally pass services that have proxy-auth capabilities the name of the realm the plugin is registered for. Adding a value for `config.realm` will cause that value to be passed as `X-Oauth-realm` with all authenticated requests, but only if the value of `config.realm` is present in the URL. This should mitigate the chance for spoofing, but that would also require the abuser to have access to your upstream service and control over the kong -admin api.