### PR TITLE
feat: role restriction

### DIFF
--- a/src/access.lua
+++ b/src/access.lua
@@ -40,7 +40,6 @@ local function getUserInfo(access_token, callback_url, conf)
   end
 
   local userJson = cjson.decode(res.body)
-  ngx.log(ngx.ERR, "USER-INFO", dump(userJson))
   return userJson
 end
 

--- a/src/access.lua
+++ b/src/access.lua
@@ -27,6 +27,7 @@ local function getUserInfo(access_token, callback_url, conf)
   end
 
   local userJson = cjson.decode(res.body)
+  ngx.log(ngx.ERR, "USER-INFO", dump(userJson))
   return userJson
 end
 

--- a/src/access.lua
+++ b/src/access.lua
@@ -53,6 +53,8 @@ local function is_member(_obj, _set)
 end
 
 local function validate_roles(conf, token)
+  ngx.log(conf)
+  ngx.log(token)
   local _allowed_roles = conf.allowed_roles
   local _next = next(_allowed_roles)
   if _next == nil then

--- a/src/access.lua
+++ b/src/access.lua
@@ -59,6 +59,7 @@ end
 
 local function is_member(_obj, _set)
   for _,v in pairs(_set) do
+    ngx.log(ngx.ERR, 'checking', v)
     if v == _obj then
       return true
     end
@@ -77,7 +78,6 @@ local function validate_roles(conf, token)
   while (_next ~= nil) do
     if (is_member(_next, token["groups"]) == true) then
       return true
-      break
     end
     _next = next(_allowed_roles)
     ngx.log(ngx.ERR, 'Checking', _next)

--- a/src/access.lua
+++ b/src/access.lua
@@ -69,14 +69,13 @@ end
 
 local function validate_roles(conf, token)
   ngx.log(ngx.ERR, dump(token))
-  ngx.log(ngx.ERR, dump(conf))
   local _allowed_roles = conf.allowed_roles
   local _next = next(_allowed_roles)
   if _next == nil then
    return true-- no roles provided for checking. Ok.
   end
   while (_next ~= nil) do
-    if (is_member(_next, token["realm_access"]["roles"]) == true) then
+    if (is_member(_next, token["groups"]) == true) then
       return true
     end
     _next = next(_allowed_roles)

--- a/src/access.lua
+++ b/src/access.lua
@@ -260,10 +260,10 @@ function _M.run(conf)
 		local userInfo = getKongKey(encrypted_token, access_token, callback_url, conf)
 		if userInfo then
       -- Check if allowed_roles is set && enforce
-      local valid = validate_roles(conf, userInfo)
-      if valid == false then
-        return kong.response.exit(401, { message = "User lacks valid role for this OIDC resource" })
-      end
+      -- local valid = validate_roles(conf, userInfo)
+      -- if valid == false then
+      --   return kong.response.exit(401, { message = "User lacks valid role for this OIDC resource" })
+      -- end
 		  for i, key in ipairs(conf.user_keys) do
 		      ngx.header["X-Oauth-".. key] = userInfo[key]
 		      ngx.req.set_header("X-Oauth-".. key, userInfo[key])

--- a/src/access.lua
+++ b/src/access.lua
@@ -61,13 +61,13 @@ local function dump(o)
       end
       return s .. '} '
    else
-      return ngx.log(ngx.ERR, tostring(o))
+      return tostring(o)
    end
 end
 
 local function validate_roles(conf, token)
-  dump(token)
-  dump(conf)
+  ngx.log(ngx.ERR, dump(token))
+  ngx.log(ngx.ERR, dump(conf))
   local _allowed_roles = conf.allowed_roles
   local _next = next(_allowed_roles)
   if _next == nil then

--- a/src/access.lua
+++ b/src/access.lua
@@ -260,10 +260,10 @@ function _M.run(conf)
 		local userInfo = getKongKey(encrypted_token, access_token, callback_url, conf)
 		if userInfo then
       -- Check if allowed_roles is set && enforce
-      -- local valid = validate_roles(conf, userInfo)
-      -- if valid == false then
-      --   return kong.response.exit(401, { message = "User lacks valid role for this OIDC resource" })
-      -- end
+      local valid = validate_roles(conf, access_token)
+      if valid == false then
+        return kong.response.exit(401, { message = "User lacks valid role for this OIDC resource" })
+      end
 		  for i, key in ipairs(conf.user_keys) do
 		      ngx.header["X-Oauth-".. key] = userInfo[key]
 		      ngx.req.set_header("X-Oauth-".. key, userInfo[key])

--- a/src/access.lua
+++ b/src/access.lua
@@ -11,6 +11,19 @@ local oidc_error = nil
 local salt = nil --16 char alphanumeric
 local cookieDomain = nil
 
+local function dump(o)
+   if type(o) == 'table' then
+      local s = '{ '
+      for k,v in pairs(o) do
+         if type(k) ~= 'number' then k = '"'..k..'"' end
+         s = s .. '['..k..'] = ' .. dump(v) .. ','
+      end
+      return s .. '} '
+   else
+      return tostring(o)
+   end
+end
+
 local function getUserInfo(access_token, callback_url, conf)
     local httpc = http:new()
     local res, err = httpc:request_uri(conf.user_url, {
@@ -53,18 +66,6 @@ local function is_member(_obj, _set)
   return false
 end
 
-local function dump(o)
-   if type(o) == 'table' then
-      local s = '{ '
-      for k,v in pairs(o) do
-         if type(k) ~= 'number' then k = '"'..k..'"' end
-         s = s .. '['..k..'] = ' .. dump(v) .. ','
-      end
-      return s .. '} '
-   else
-      return tostring(o)
-   end
-end
 
 local function validate_roles(conf, token)
   ngx.log(ngx.ERR, dump(token))

--- a/src/access.lua
+++ b/src/access.lua
@@ -261,7 +261,7 @@ function _M.run(conf)
 		local userInfo = getKongKey(encrypted_token, access_token, callback_url, conf)
 		if userInfo then
       -- Check if allowed_roles is set && enforce
-      local valid = validate_roles(conf, access_token)
+      local valid = validate_roles(conf, userInfo)
       if valid == false then
         return kong.response.exit(401, { message = "User lacks valid role for this OIDC resource" })
       end

--- a/src/access.lua
+++ b/src/access.lua
@@ -77,8 +77,10 @@ local function validate_roles(conf, token)
   while (_next ~= nil) do
     if (is_member(_next, token["groups"]) == true) then
       return true
+      break
     end
     _next = next(_allowed_roles)
+    ngx.log(ngx.ERR, 'Checking', _next)
   end
   return false -- no matching roles
 end
@@ -263,6 +265,7 @@ function _M.run(conf)
       -- Check if allowed_roles is set && enforce
       local valid = validate_roles(conf, userInfo)
       if valid == false then
+        ngx.log(ngx.ERR, 'Roles invalid')
         return kong.response.exit(401, { message = "User lacks valid role for this OIDC resource" })
       end
 		  for i, key in ipairs(conf.user_keys) do
@@ -287,6 +290,7 @@ function _M.run(conf)
         -- Check if allowed_roles is set && enforce
         local valid = validate_roles(conf, json)
         if valid == false then
+          ngx.log(ngx.ERR, 'Roles invalid')
           return kong.response.exit(401, { message = "User lacks valid role for this OIDC resource" })
         end
 		    if conf.hosted_domain ~= "" and conf.email_key ~= "" then

--- a/src/access.lua
+++ b/src/access.lua
@@ -59,7 +59,7 @@ local function validate_roles(conf, token)
    return true-- no roles provided for checking. Ok.
   end
   while (_next ~= nil) do
-    if (is_member(_next, token['roles']) == true) then
+    if (is_member(_next, token["realm_access"]["roles"]) == true) then
       return true
     end
     _next = next(_allowed_roles)

--- a/src/access.lua
+++ b/src/access.lua
@@ -75,12 +75,11 @@ local function validate_roles(conf, token)
   if _next == nil then
    return true-- no roles provided for checking. Ok.
   end
-  while (_next ~= nil) do
-    if (is_member(_next, token["groups"]) == true) then
+  for _, role in pairs(_allowed_roles) do
+    ngx.log(ngx.ERR, 'Checking', role)
+    if (is_member(role, token["groups"]) == true) then
       return true
     end
-    _next = next(_allowed_roles)
-    ngx.log(ngx.ERR, 'Checking', _next)
   end
   return false -- no matching roles
 end

--- a/src/access.lua
+++ b/src/access.lua
@@ -52,9 +52,22 @@ local function is_member(_obj, _set)
   return false
 end
 
+local function dump(o)
+   if type(o) == 'table' then
+      local s = '{ '
+      for k,v in pairs(o) do
+         if type(k) ~= 'number' then k = '"'..k..'"' end
+         s = s .. '['..k..'] = ' .. dump(v) .. ','
+      end
+      return s .. '} '
+   else
+      return ngx.log(ngx.ERR, tostring(o))
+   end
+end
+
 local function validate_roles(conf, token)
-  ngx.log(conf)
-  ngx.log(token)
+  dump(token)
+  dump(conf)
   local _allowed_roles = conf.allowed_roles
   local _next = next(_allowed_roles)
   if _next == nil then

--- a/src/schema.lua
+++ b/src/schema.lua
@@ -33,6 +33,7 @@ return {
     user_info_periodic_check = {type = "number", required = true, default = 60},
     hosted_domain = {type = "string", default = ""},
     realm = {type = "string", default = ""},
+    allowed_roles = {type = "array", default = {}},
     email_key = {type = "string", default = ""},
     user_info_cache_enabled = {type = "boolean", default = false}
   }


### PR DESCRIPTION
Keycloak / OIDC is configurable about what roles (realm / client, etc) goes into the access token. OIDC also has a userinfo endpoint which you can configure to show some of the information using a person's access key to see the endpoint, but without actually opening the token. That's what this plugin does. The plugin also lets you configure which fields from userinfo you want to pass as individual headers.

My goal was to allow an app that doesn't know how to act on roles to still only be available for a subset of users on a realm. So I'm doing the following:
 - Change our default KC setup so that `realm_roles` is included in `oidc.userinfo` as `groups` (which is one of it's suggested behaviors)
 - Add a optional setting to the OIDC Kong plugin for `allowed_roles`
 - Add logic to the Kong plugin that checks `allowed_roles` for any overlap with `oidc.userinfo.groups` and throw a gateway 401 if they lack permission

With that in place, you have two options for using groups.
- You can set `allowed_roles` in your service configuration to only allow some types of users to a route
- You can allow all roles to pass the gateway and then either decode the access_token, or use the header X-Oauth-groups to decide what to do with each request.