### PR TITLE
feat: basic auth

### DIFF
--- a/src/access.lua
+++ b/src/access.lua
@@ -11,37 +11,42 @@ local oidc_error = nil
 local salt = nil --16 char alphanumeric
 local cookieDomain = nil
 
+
+-- Convenience function for logging objects... because LUA...
 local function dump(o)
-   if type(o) == 'table' then
-      local s = '{ '
-      for k,v in pairs(o) do
-         if type(k) ~= 'number' then k = '"'..k..'"' end
-         s = s .. '['..k..'] = ' .. dump(v) .. ','
+  if type(o) == 'table' then
+    local s = '{ '
+    for k,v in pairs(o) do
+      if type(k) ~= 'number' then
+        k = '"'..k..'"' 
       end
-      return s .. '} '
-   else
-      return tostring(o)
-   end
+      s = s .. '['..k..'] = ' .. dump(v) .. ','
+    end
+    return s .. '} '
+  else
+    return tostring(o)
+  end
 end
 
-local function getUserInfo(access_token, callback_url, conf)
-    local httpc = http:new()
-    local res, err = httpc:request_uri(conf.user_url, {
-        method = "GET",
-        ssl_verify = false,
-        headers = {
-          ["Authorization"] = "Bearer " .. access_token,
-        }
-    })
 
+-- get Userinfo from AuthProvider's userinfo endpoint
+local function getUserInfo(access_token, callback_url, conf)
+  local httpc = http:new()
+  local res, err = httpc:request_uri(conf.user_url, {
+      method = "GET",
+      ssl_verify = false,
+      headers = {
+        ["Authorization"] = "Bearer " .. access_token,
+      }
+  })
   -- redirect to auth if user result is invalid not 200
   if res.status ~= 200 then
-     return redirect_to_auth(conf, callback_url)
+    return redirect_to_auth(conf, callback_url)
   end
-
   local userJson = cjson.decode(res.body)
   return userJson
 end
+
 
 local function getKongKey(eoauth_token, access_token, callback_url, conf)
   -- This will add a 28800 second (8 hour) expiring TTL on this cached value
@@ -51,11 +56,11 @@ local function getKongKey(eoauth_token, access_token, callback_url, conf)
   if err then
     ngx.log(ngx.ERR, "Could not retrieve UserInfo: ", err)
     return
-  end
-    
+  end  
   return userInfo
 end
 
+-- Checks if an object exists in a set
 local function is_member(_obj, _set)
   for _,v in pairs(_set) do
     if v == _obj then
@@ -84,6 +89,7 @@ local function validate_roles(conf, token)
   return false -- no matching roles
 end
 
+
 function redirect_to_auth( conf, callback_url )
     -- Track the endpoint they wanted access to so we can transparently redirect them back
     if type(ngx.header["Set-Cookie"]) == "table" then
@@ -103,9 +109,11 @@ function redirect_to_auth( conf, callback_url )
     return ngx.redirect(oauth_authorize)
 end
 
+
 function encode_token(token, conf)
       return ngx.encode_base64(aes:encrypt(openssl_digest.new("md5"):final(conf.client_secret), salt, true):final(token))
 end
+
 
 function decode_token(token, conf)
     local status, token = pcall(function () return aes:decrypt(openssl_digest.new("md5"):final(conf.client_secret), salt, true):final(ngx.decode_base64(token)) end)
@@ -116,6 +124,7 @@ function decode_token(token, conf)
         return nil
     end
 end
+
 
 -- Logout Handling
 function  handle_logout(encrypted_token, conf)
@@ -133,101 +142,101 @@ function  handle_logout(encrypted_token, conf)
     end
   end
    
-
    -- Remove session
    if conf.user_info_cache_enabled then
       singletons.cache:invalidate(encrypted_token)
    end
    -- Redirect to IAM service logout
    return ngx.redirect(redirect_url)
-
 end
+
 
 -- Callback Handling
 function  handle_callback( conf, callback_url )
-    local args = ngx.req.get_uri_args()
-    local code = args.code
-    local redirect_url
+  local args = ngx.req.get_uri_args()
+  local code = args.code
+  local redirect_url
 
-    if args.redirect_url == nil then
-       redirect_url = callback_url
-    else
-       redirect_url = args.redirect_url
+  if args.redirect_url == nil then
+    redirect_url = callback_url
+  else
+    redirect_url = args.redirect_url
+  end
+  
+  if code then
+    local httpc = http:new()
+    local res, err = httpc:request_uri(conf.token_url, {
+      method = "POST",
+      ssl_verify = false,
+      body = "grant_type=authorization_code&client_id=" .. conf.client_id .. "&client_secret=" .. conf.client_secret .. "&code=" .. code .. "&redirect_uri=" .. redirect_url,
+      headers = {
+        ["Content-Type"] = "application/x-www-form-urlencoded",
+      }
+    })
+
+    if not res then
+      oidc_error = {status = ngx.HTTP_INTERNAL_SERVER_ERROR, message = "Failed to request: " .. err}
+      return kong.response.exit(oidc_error.status, { message = oidc_error.message })
     end
+
+    local json = cjson.decode(res.body)
+    local access_token = json.access_token
+    if not access_token then
+      oidc_error = {status = ngx.HTTP_BAD_REQUEST, message = json.error_description}
+      return kong.response.exit(oidc_error.status, { message = oidc_error.message })
+    end
+
+    if type(ngx.header["Set-Cookie"]) == "table" then
+      ngx.header["Set-Cookie"] = { "EOAuthToken=" .. encode_token(access_token, conf) .. ";Path=/;Expires=" .. ngx.cookie_time(ngx.time() + 1800) .. ";Max-Age=1800;HttpOnly" .. cookieDomain, unpack(ngx.header["Set-Cookie"]) }
+      if conf.realm ~= nil then
+        ngx.header["Set-Cookie"] = {"EOAuthRealm=" .. conf.realm .. ";Path=/;Expires=" .. ngx.cookie_time(ngx.time() + 1800) .. ";Max-Age=1800;HttpOnly" .. cookieDomain, unpack(ngx.header["Set-Cookie"]) }
+      end
+    else
+      ngx.header["Set-Cookie"] = { "EOAuthToken=" .. encode_token(access_token, conf) .. ";Path=/;Expires=" .. ngx.cookie_time(ngx.time() + 1800) .. ";Max-Age=1800;HttpOnly" .. cookieDomain, ngx.header["Set-Cookie"] }
+      if conf.realm ~= nil then
+        ngx.header["Set-Cookie"] = {"EOAuthRealm=" .. conf.realm .. ";Path=/;Expires=" .. ngx.cookie_time(ngx.time() + 1800) .. ";Max-Age=1800;HttpOnly" .. cookieDomain, ngx.header["Set-Cookie"] }
+      end
+    end
+      
+    -- Support redirection back to Kong if necessary
+    local redirect_back = ngx.var.cookie_EOAuthRedirectBack
     
-    if code then
-        local httpc = http:new()
-        local res, err = httpc:request_uri(conf.token_url, {
-            method = "POST",
-            ssl_verify = false,
-            body = "grant_type=authorization_code&client_id=" .. conf.client_id .. "&client_secret=" .. conf.client_secret .. "&code=" .. code .. "&redirect_uri=" .. redirect_url,
-            headers = {
-              ["Content-Type"] = "application/x-www-form-urlencoded",
-            }
-        })
-
-        if not res then
-            oidc_error = {status = ngx.HTTP_INTERNAL_SERVER_ERROR, message = "Failed to request: " .. err}
-            return kong.response.exit(oidc_error.status, { message = oidc_error.message })
-        end
-
-        local json = cjson.decode(res.body)
-        local access_token = json.access_token
-        if not access_token then
-            oidc_error = {status = ngx.HTTP_BAD_REQUEST, message = json.error_description}
-            return kong.response.exit(oidc_error.status, { message = oidc_error.message })
-        end
-
-        if type(ngx.header["Set-Cookie"]) == "table" then
-           ngx.header["Set-Cookie"] = { "EOAuthToken=" .. encode_token(access_token, conf) .. ";Path=/;Expires=" .. ngx.cookie_time(ngx.time() + 1800) .. ";Max-Age=1800;HttpOnly" .. cookieDomain, unpack(ngx.header["Set-Cookie"]) }
-          if conf.realm ~= nil then
-            ngx.header["Set-Cookie"] = {"EOAuthRealm=" .. conf.realm .. ";Path=/;Expires=" .. ngx.cookie_time(ngx.time() + 1800) .. ";Max-Age=1800;HttpOnly" .. cookieDomain, unpack(ngx.header["Set-Cookie"]) }
-          end
-        else
-          ngx.header["Set-Cookie"] = { "EOAuthToken=" .. encode_token(access_token, conf) .. ";Path=/;Expires=" .. ngx.cookie_time(ngx.time() + 1800) .. ";Max-Age=1800;HttpOnly" .. cookieDomain, ngx.header["Set-Cookie"] }
-          if conf.realm ~= nil then
-            ngx.header["Set-Cookie"] = {"EOAuthRealm=" .. conf.realm .. ";Path=/;Expires=" .. ngx.cookie_time(ngx.time() + 1800) .. ";Max-Age=1800;HttpOnly" .. cookieDomain, ngx.header["Set-Cookie"] }
-          end
-        end
-        
-
-        -- Support redirection back to Kong if necessary
-        local redirect_back = ngx.var.cookie_EOAuthRedirectBack
-        
-        if redirect_back then
-            return ngx.redirect(redirect_back) --Should always land here if no custom Loggedin page defined!
-        else
-          --return redirect_to_auth(conf, callback_url)
-           return
-        end
+    if redirect_back then
+      return ngx.redirect(redirect_back) --Should always land here if no custom Loggedin page defined!
     else
-        oidc_error = {status = ngx.HTTP_UNAUTHORIZED, message = "User has denied access to the resources"}
-        return kong.response.exit(oidc_error.status, { message = oidc_error.message })
+      --return redirect_to_auth(conf, callback_url)
+      return
     end
+  else
+    oidc_error = {status = ngx.HTTP_UNAUTHORIZED, message = "User has denied access to the resources"}
+    return kong.response.exit(oidc_error.status, { message = oidc_error.message })
+  end
 end
 
-function _M.run(conf)
-    local path_prefix = ""
-    local callback_url = ""
-    cookieDomain = ";Domain=" .. conf.cookie_domain
-    salt = conf.salt
 
-    --Fix for /api/team/POC/oidc/v1/service/oauth2/callback?code=*******
-    if ngx.var.request_uri:find('?') then
-      path_prefix = ngx.var.request_uri:sub(1, ngx.var.request_uri:find('?') -1)
-    else
-      path_prefix = ngx.var.request_uri
-    end
-    
-    if pl_stringx.endswith(path_prefix, "/") then
-      path_prefix = path_prefix:sub(1, path_prefix:len() - 1)
-      callback_url = ngx.var.scheme .. "://" .. ngx.var.host .. path_prefix .. "/oauth2/callback"
-    elseif pl_stringx.endswith(path_prefix, "/oauth2/callback") then --We are in the callback of our proxy
-      callback_url = ngx.var.scheme .. "://" .. ngx.var.host .. path_prefix
-    handle_callback(conf, callback_url)
-    else
-      callback_url = ngx.var.scheme .. "://" .. ngx.var.host .. path_prefix .. "/oauth2/callback"
-    end
+-- MAIN Function that Kong runs
+function _M.run(conf)
+  local path_prefix = ""
+  local callback_url = ""
+  cookieDomain = ";Domain=" .. conf.cookie_domain
+  salt = conf.salt
+
+  --Fix for /api/team/POC/oidc/v1/service/oauth2/callback?code=*******
+  if ngx.var.request_uri:find('?') then
+    path_prefix = ngx.var.request_uri:sub(1, ngx.var.request_uri:find('?') -1)
+  else
+    path_prefix = ngx.var.request_uri
+  end
+  
+  if pl_stringx.endswith(path_prefix, "/") then
+    path_prefix = path_prefix:sub(1, path_prefix:len() - 1)
+    callback_url = ngx.var.scheme .. "://" .. ngx.var.host .. path_prefix .. "/oauth2/callback"
+  elseif pl_stringx.endswith(path_prefix, "/oauth2/callback") then --We are in the callback of our proxy
+    callback_url = ngx.var.scheme .. "://" .. ngx.var.host .. path_prefix
+  handle_callback(conf, callback_url)
+  else
+    callback_url = ngx.var.scheme .. "://" .. ngx.var.host .. path_prefix .. "/oauth2/callback"
+  end
 
   -- See if we have a token
   
@@ -256,7 +265,7 @@ function _M.run(conf)
     access_token = decode_token(encrypted_token, conf)
     if not access_token then
     -- broken access token
-       return redirect_to_auth( conf, callback_url )
+       return redirect_to_auth(conf, callback_url)
     end
   end
   
@@ -278,68 +287,65 @@ function _M.run(conf)
     end
   end
   
-
    --CACHE LOGIC - Check boolean and then if EOAUTH has existing key -> userInfo value
   if conf.user_info_cache_enabled then
-        local userInfo = getKongKey(encrypted_token, access_token, callback_url, conf)
-        if userInfo then
+    local userInfo = getKongKey(encrypted_token, access_token, callback_url, conf)
+    if userInfo then
       -- Check if allowed_roles is set && enforce
       local valid = validate_roles(conf, userInfo)
       if valid == false then
         return kong.response.exit(401, { message = "User lacks valid role for this OIDC resource" })
       end
-          for i, key in ipairs(conf.user_keys) do
-              ngx.header["X-Oauth-".. key] = userInfo[key]
-              ngx.req.set_header("X-Oauth-".. key, userInfo[key])
-          end
+      for i, key in ipairs(conf.user_keys) do
+        ngx.header["X-Oauth-".. key] = userInfo[key]
+        ngx.req.set_header("X-Oauth-".. key, userInfo[key])
+      end
       if (conf.realm ~= "" and (pl_stringx.count(ngx.var.request_uri, conf.realm) > 0)) then -- inject realm name into headers
        ngx.header["X-Oauth-realm"] = conf.realm
        ngx.req.set_header("X-Oauth-realm", conf.realm)
       end
       ngx.req.set_header("X-Oauth-Token", access_token)
       ngx.header["X-Oauth-Token"] = access_token
-          return
-        end
+      return
+    end
   end
   -- END OF NEW CACHE LOGIC --
 
   -- Get user info
   if not ngx.var.cookie_EOAuthUserInfo then
-        local json = getUserInfo(access_token, callback_url, conf)
-
-        if json then
-        -- Check if allowed_roles is set && enforce
-        local valid = validate_roles(conf, json)
-        if valid == false then
-          return kong.response.exit(401, { message = "User lacks valid role for this OIDC resource" })
+    local json = getUserInfo(access_token, callback_url, conf)
+    if json then
+      -- Check if allowed_roles is set && enforce
+      local valid = validate_roles(conf, json)
+      if valid == false then
+        return kong.response.exit(401, { message = "User lacks valid role for this OIDC resource" })
+      end
+      if conf.hosted_domain ~= "" and conf.email_key ~= "" then
+        if not pl_stringx.endswith(json[conf.email_key], conf.hosted_domain) then
+          oidc_error = {status = ngx.HTTP_UNAUTHORIZED, message = "Hosted domain is not matching"}
+          return kong.response.exit(oidc_error.status, { message = oidc_error.message })
         end
-            if conf.hosted_domain ~= "" and conf.email_key ~= "" then
-                if not pl_stringx.endswith(json[conf.email_key], conf.hosted_domain) then
-                    oidc_error = {status = ngx.HTTP_UNAUTHORIZED, message = "Hosted domain is not matching"}
-                    return kong.response.exit(oidc_error.status, { message = oidc_error.message })
-                end
-            end
+      end
 
-            for i, key in ipairs(conf.user_keys) do
-                ngx.header["X-Oauth-".. key] = json[key]
-                ngx.req.set_header("X-Oauth-".. key, json[key])
-            end
-        if (conf.realm ~= "" and (pl_stringx.count(ngx.var.request_uri, conf.realm) > 0)) then -- inject realm name into headers
-          ngx.header["X-Oauth-realm"] = conf.realm
-          ngx.req.set_header("X-Oauth-realm", conf.realm)
-        end
-            ngx.req.set_header("X-Oauth-Token", access_token)
-            ngx.header["X-Oauth-Token"] = access_token
+      for i, key in ipairs(conf.user_keys) do
+        ngx.header["X-Oauth-".. key] = json[key]
+        ngx.req.set_header("X-Oauth-".. key, json[key])
+      end
+      if (conf.realm ~= "" and (pl_stringx.count(ngx.var.request_uri, conf.realm) > 0)) then -- inject realm name into headers
+        ngx.header["X-Oauth-realm"] = conf.realm
+        ngx.req.set_header("X-Oauth-realm", conf.realm)
+      end
+      ngx.req.set_header("X-Oauth-Token", access_token)
+      ngx.header["X-Oauth-Token"] = access_token
 
-            if type(ngx.header["Set-Cookie"]) == "table" then
-                ngx.header["Set-Cookie"] = { "EOAuthUserInfo=0;Path=/;Expires=" .. ngx.cookie_time(ngx.time() + conf.user_info_periodic_check) .. ";Max-Age=" .. conf.user_info_periodic_check .. ";HttpOnly", unpack(ngx.header["Set-Cookie"]) }
-            else
-                ngx.header["Set-Cookie"] = { "EOAuthUserInfo=0;Path=/;Expires=" .. ngx.cookie_time(ngx.time() + conf.user_info_periodic_check) .. ";Max-Age=" .. conf.user_info_periodic_check .. ";HttpOnly", ngx.header["Set-Cookie"] }
-            end
-
-        else
-            return kong.response.exit(500, { message = err })
-        end
+      if type(ngx.header["Set-Cookie"]) == "table" then
+          ngx.header["Set-Cookie"] = { "EOAuthUserInfo=0;Path=/;Expires=" .. ngx.cookie_time(ngx.time() + conf.user_info_periodic_check) .. ";Max-Age=" .. conf.user_info_periodic_check .. ";HttpOnly", unpack(ngx.header["Set-Cookie"]) }
+      else
+          ngx.header["Set-Cookie"] = { "EOAuthUserInfo=0;Path=/;Expires=" .. ngx.cookie_time(ngx.time() + conf.user_info_periodic_check) .. ";Max-Age=" .. conf.user_info_periodic_check .. ";HttpOnly", ngx.header["Set-Cookie"] }
+      end
+    else
+      return kong.response.exit(500, { message = err })
+    end
   end
 end
 

--- a/src/access.lua
+++ b/src/access.lua
@@ -297,24 +297,14 @@ function _M.run(conf)
     _, _, base64_basic = string.find(auth_header, "Basic%s+(.+)")
     if base64_basic ~= nil then
       local hashed = encode_token(base64_basic, conf)
-      encrypted_token, err = singletons.cache:get("basicauth." .. hashed, nil, tokenFromBasic, base64_basic, conf)
+      encrypted_token, err = singletons.cache:get(
+        "basicauth." .. hashed,
+        {ttl = conf.user_info_periodic_check},
+        tokenFromBasic, base64_basic, conf
+      )
       if err then
         return response.HTTP_INTERNAL_SERVER_ERROR(err)
       end
-      -- local plain_text = ngx.decode_base64(base64_basic)
-      -- local c = credsFromBasic(plain_text)
-      -- if c["user"] == nil or c["pw"] == nil then
-      --   return kong.response.exit(400, { message = "Malformed Basic Auth Request" })
-      -- end
-      -- local res, err = getTokenViaBasic(c["user"], c["pw"], conf)
-      -- if err ~= nil then
-      --   return kong.response.exit(400, { message = "Could not perform basic auth" })
-      -- end
-      -- if res.status ~= 200 then
-      --   return kong.response.exit(res.status, { message = res.body })
-      -- end
-      -- local userJson = cjson.decode(res.body)
-      -- encrypted_token = encode_token(userJson['access_token'], conf)
     end
   else
     -- Try to get token from cookie

--- a/src/access.lua
+++ b/src/access.lua
@@ -160,7 +160,7 @@ end
 
 -- Get A token via PasswordGrant
 
-local function getTokenViaBasic(user, pw, conf)
+function getTokenViaBasic(user, pw, conf)
   local res, err = httpc:request_uri(conf.token_url, {
     method = "POST",
     ssl_verify = false,

--- a/src/access.lua
+++ b/src/access.lua
@@ -299,7 +299,7 @@ function _M.run(conf)
       local hashed = encode_token(base64_basic, conf)
       encrypted_token, err = singletons.cache:get("basicauth." .. hashed, { ttl = conf.user_info_periodic_check }, tokenFromBasic, base64_basic, conf)
       if err then
-        return response.HTTP_INTERNAL_SERVER_ERROR(err)
+        return kong.response.HTTP_INTERNAL_SERVER_ERROR(err)
       end
     end
   else

--- a/src/access.lua
+++ b/src/access.lua
@@ -287,7 +287,8 @@ function _M.run(conf)
   local auth_header = ngx.var.http_Authorization
   local _ -- Keep off the global scope
   local encrypted_token
-
+  local err
+  
   if auth_header then
     _, _, access_token = string.find(auth_header, "Bearer%s+(.+)")
   end
@@ -299,7 +300,7 @@ function _M.run(conf)
       local hashed = encode_token(base64_basic, conf)
       encrypted_token, err = singletons.cache:get("basicauth." .. hashed, { ttl = conf.user_info_periodic_check }, tokenFromBasic, base64_basic, conf)
       if err then
-        return kong.response.HTTP_INTERNAL_SERVER_ERROR(err)
+        return kong.response.exit(401, err)
       end
     end
   else

--- a/src/access.lua
+++ b/src/access.lua
@@ -289,8 +289,9 @@ function _M.run(conf)
         return kong.response.exit(res.status, { message = res.body })
       end
       local userJson = cjson.decode(res.body)
-      ngx.log(ngx.ERR, "token: ", dump(userJson))
-      -- encrypted_token = encode_token(access_token, conf)
+      local encrypted_token = encode_token(userJson['access_token'], conf)
+      -- ngx.log(ngx.ERR, "token: ", dump(userJson))
+      -- -- encrypted_token = encode_token(access_token, conf)
     end
   else
     -- Try to get token from cookie

--- a/src/access.lua
+++ b/src/access.lua
@@ -160,7 +160,7 @@ end
 
 -- Get A token via PasswordGrant
 
-local function getTokenViaBasic(user, pw)
+local function getTokenViaBasic(user, pw, conf)
   local res, err = httpc:request_uri(conf.token_url, {
     method = "POST",
     ssl_verify = false,
@@ -280,7 +280,7 @@ function _M.run(conf)
       if c["user"] == nil or c["pw"] == nil then
         return kong.response.exit(400, { message = "Malformed Basic Auth Request" })
       end
-      local res, err = getTokenViaBasic(c["user"], c["pw"])
+      local res, err = getTokenViaBasic(c["user"], c["pw"], conf)
       if err ~= nil then
         return kong.response.exit(400, { message = "Could not perform basic auth" })
       end

--- a/src/access.lua
+++ b/src/access.lua
@@ -297,11 +297,7 @@ function _M.run(conf)
     _, _, base64_basic = string.find(auth_header, "Basic%s+(.+)")
     if base64_basic ~= nil then
       local hashed = encode_token(base64_basic, conf)
-      encrypted_token, err = singletons.cache:get(
-        "basicauth." .. hashed,
-        {ttl = conf.user_info_periodic_check},
-        tokenFromBasic, base64_basic, conf
-      )
+      encrypted_token, err = singletons.cache:get("basicauth." .. hashed, { ttl = conf.user_info_periodic_check }, tokenFromBasic, base64_basic, conf)
       if err then
         return response.HTTP_INTERNAL_SERVER_ERROR(err)
       end

--- a/src/access.lua
+++ b/src/access.lua
@@ -160,7 +160,8 @@ end
 
 -- Get A token via PasswordGrant
 
-function getTokenViaBasic(user, pw, conf)
+local function getTokenViaBasic(user, pw, conf)
+  local httpc = http:new()
   local res, err = httpc:request_uri(conf.token_url, {
     method = "POST",
     ssl_verify = false,

--- a/src/access.lua
+++ b/src/access.lua
@@ -289,7 +289,7 @@ function _M.run(conf)
         return kong.response.exit(res.status, { message = res.body })
       end
       local userJson = cjson.decode(res.body)
-      ngx.log(ngx.ERR, "token: ", userJson)
+      ngx.log(ngx.ERR, "token: ", dump(userJson))
       -- encrypted_token = encode_token(access_token, conf)
     end
   else

--- a/src/access.lua
+++ b/src/access.lua
@@ -297,7 +297,7 @@ function _M.run(conf)
     _, _, base64_basic = string.find(auth_header, "Basic%s+(.+)")
     if base64_basic ~= nil then
       local hashed = encode_token(base64_basic, conf)
-      encrypted_token, err = cache:get("basicauth." .. hashed, nil, tokenFromBasic, base64_basic, conf)
+      encrypted_token, err = singletons.cache:get("basicauth." .. hashed, nil, tokenFromBasic, base64_basic, conf)
       if err then
         return response.HTTP_INTERNAL_SERVER_ERROR(err)
       end

--- a/src/access.lua
+++ b/src/access.lua
@@ -12,6 +12,14 @@ local salt = nil --16 char alphanumeric
 local cookieDomain = nil
 
 
+
+local function credsFromBasic(authString)
+  -- local m, err = ngx.re.match(ngx.var.uri, "/(?<app>[^/]+)-app(?<url>.+)", "ao")
+  local m, err = ngx.re.match(authString, "(?<user>[^:]+):(?<pw>[^:]+)", "ao")
+  -- local user = string.gmatch(authString, '([^:]+)')
+  return m
+end
+
 -- Convenience function for logging objects... because LUA...
 local function dump(o)
   if type(o) == 'table' then
@@ -255,6 +263,9 @@ function _M.run(conf)
     if base64_basic ~= nil then
       local plain_text = ngx.decode_base64(base64_basic)
       ngx.log(ngx.ERR, "plain_text: ", plain_text)
+      local c = credsFromBasic(plain_text)
+      ngx.log(ngx.ERR, "user: ", c["user"])
+      ngx.log(ngx.ERR, "pw: ", c["pw"])
     end
   end
 

--- a/src/access.lua
+++ b/src/access.lua
@@ -133,38 +133,36 @@ end
 
 
 function redirect_to_auth( conf, callback_url )
-    -- Track the endpoint they wanted access to so we can transparently redirect them back
-    if type(ngx.header["Set-Cookie"]) == "table" then
+  -- Track the endpoint they wanted access to so we can transparently redirect them back
+  if type(ngx.header["Set-Cookie"]) == "table" then
     ngx.header["Set-Cookie"] = { "EOAuthRedirectBack=" .. ngx.var.request_uri .. ";Path=/;Expires=" .. ngx.cookie_time(ngx.time() + 120) .. ";Max-Age=120;HttpOnly", unpack(ngx.header["Set-Cookie"]) }
-    else
+  else
     ngx.header["Set-Cookie"] = { "EOAuthRedirectBack=" .. ngx.var.request_uri .. ";Path=/;Expires=" .. ngx.cookie_time(ngx.time() + 120) .. ";Max-Age=120;HttpOnly", ngx.header["Set-Cookie"] }
-    end
-    
-    -- Redirect to the /oauth endpoint
-    local oauth_authorize = nil
-    if(conf.pf_idp_adapter_id == "") then --Standard Auth URL(Something other than ping)
-       oauth_authorize = conf.authorize_url .. "?response_type=code&client_id=" .. conf.client_id .. "&redirect_uri=" .. callback_url .. "&scope=" .. conf.scope
-    else --Ping Federate Auth URL
-         oauth_authorize = conf.authorize_url .. "?pfidpadapterid=" .. conf.pf_idp_adapter_id .. "&response_type=code&client_id=" .. conf.client_id .. "&redirect_uri=" .. callback_url .. "&scope=" .. conf.scope
-    end
-    
-    return ngx.redirect(oauth_authorize)
+  end
+  
+  -- Redirect to the /oauth endpoint
+  local oauth_authorize = nil
+  if(conf.pf_idp_adapter_id == "") then --Standard Auth URL(Something other than ping)
+    oauth_authorize = conf.authorize_url .. "?response_type=code&client_id=" .. conf.client_id .. "&redirect_uri=" .. callback_url .. "&scope=" .. conf.scope
+  else --Ping Federate Auth URL
+    oauth_authorize = conf.authorize_url .. "?pfidpadapterid=" .. conf.pf_idp_adapter_id .. "&response_type=code&client_id=" .. conf.client_id .. "&redirect_uri=" .. callback_url .. "&scope=" .. conf.scope
+  end
+  return ngx.redirect(oauth_authorize)
 end
 
 
 function encode_token(token, conf)
-      return ngx.encode_base64(aes:encrypt(openssl_digest.new("md5"):final(conf.client_secret), salt, true):final(token))
+  return ngx.encode_base64(aes:encrypt(openssl_digest.new("md5"):final(conf.client_secret), salt, true):final(token))
 end
 
 
 function decode_token(token, conf)
-    local status, token = pcall(function () return aes:decrypt(openssl_digest.new("md5"):final(conf.client_secret), salt, true):final(ngx.decode_base64(token)) end)
-    
-    if status then
-        return token
-    else
-        return nil
-    end
+  local status, token = pcall(function () return aes:decrypt(openssl_digest.new("md5"):final(conf.client_secret), salt, true):final(ngx.decode_base64(token)) end)
+  if status then
+    return token
+  else
+    return nil
+  end
 end
 
 
@@ -184,12 +182,12 @@ function  handle_logout(encrypted_token, conf)
     end
   end
    
-   -- Remove session
-   if conf.user_info_cache_enabled then
-      singletons.cache:invalidate(encrypted_token)
-   end
-   -- Redirect to IAM service logout
-   return ngx.redirect(redirect_url)
+  -- Remove session
+  if conf.user_info_cache_enabled then
+    singletons.cache:invalidate(encrypted_token)
+  end
+  -- Redirect to IAM service logout
+  return ngx.redirect(redirect_url)
 end
 
 -- Callback Handling

--- a/src/access.lua
+++ b/src/access.lua
@@ -244,8 +244,18 @@ function _M.run(conf)
   
   local access_token = nil
   local auth_header = ngx.var.http_Authorization
+  local _ -- Keep off the global scope
   if auth_header then
     _, _, access_token = string.find(auth_header, "Bearer%s+(.+)")
+  end
+  if auth_header and access_token == nil then
+    ngx.log(ngx.ERR, "auth_header: ", auth_header)
+    local base64_basic
+    _, _, base64_basic = string.find(auth_header, "Basic%s+(.+)")
+    if base64_basic ~= nil then
+      local plain_text = ngx.decode_base64(base64_basic)
+      ngx.log(ngx.ERR, "plain_text: ", plain_text)
+    end
   end
 
     -- Try to get token from cookie

--- a/src/access.lua
+++ b/src/access.lua
@@ -285,7 +285,11 @@ function _M.run(conf)
       if err ~= nil then
         return kong.response.exit(400, { message = "Could not perform basic auth" })
       end
-      ngx.log(ngx.ERR, "token: ", res)
+      if res.status ~= 200 then
+        return kong.response.exit(res.status, { message = res.body })
+      end
+      local userJson = cjson.decode(res.body)
+      ngx.log(ngx.ERR, "token: ", userJson)
       -- encrypted_token = encode_token(access_token, conf)
     end
   else


### PR DESCRIPTION
Add the capability to perform basic auth directly against an OIDC protected target.

Workflow (If the BasicAuth Header is set.):
- Hash the credentials
- Check the cache for a matching access token that has the credential has as key
- If there is a valid token use it to attempt to access the OIDC resource normally.
- If there is no valid token, use the credentials to request an access token using a password grant.
- Cache the access token using the credential hash as the key with TTL -> `conf.user_info_periodic_check`
- Use the token to attempt to access the OIDC resource normally.
