### PR TITLE
Feat/x oauth unauthorized

### DIFF
--- a/src/access.lua
+++ b/src/access.lua
@@ -134,6 +134,11 @@ end
 
 function redirect_to_auth( conf, callback_url )
   -- Track the endpoint they wanted access to so we can transparently redirect them back
+  -- For Calls to indicate they prefer a 403 instead of redirect to the Oauth provider,
+  -- a header of X-Oauth-Unauthorized can be set to `status_code | login`
+  if ngx.header['X-Oauth-Unauthorized'] ~= nil and ngx.header['X-Oauth-Unauthorized'] == "status_code" then
+    return kong.response.exit(403, { message = "Forbidden: Auth redirect aborted on X-Oauth-Unauthorized == status_code" })
+  end
   if type(ngx.header["Set-Cookie"]) == "table" then
     ngx.header["Set-Cookie"] = { "EOAuthRedirectBack=" .. ngx.var.request_uri .. ";Path=/;Expires=" .. ngx.cookie_time(ngx.time() + 120) .. ";Max-Age=120;HttpOnly", unpack(ngx.header["Set-Cookie"]) }
   else

--- a/src/access.lua
+++ b/src/access.lua
@@ -136,7 +136,8 @@ function redirect_to_auth( conf, callback_url )
   -- Track the endpoint they wanted access to so we can transparently redirect them back
   -- For Calls to indicate they prefer a 403 instead of redirect to the Oauth provider,
   -- a header of X-Oauth-Unauthorized can be set to `status_code | login`
-  if ngx.header['X-Oauth-Unauthorized'] ~= nil and ngx.header['X-Oauth-Unauthorized'] == "status_code" then
+  local login_pref = ngx.req.get_headers()["X-Oauth-Unauthorized"]
+  if login_pref ~= nil and login_pref == "status_code" then
     return kong.response.exit(403, { message = "Forbidden: Auth redirect aborted on X-Oauth-Unauthorized == status_code" })
   end
   if type(ngx.header["Set-Cookie"]) == "table" then


### PR DESCRIPTION
This gives a requester the option to get a 403 instead of being redirected to the Oauth provider for login if a session is not valid.

`X-Oauth-Unauthorized : login | status_code`